### PR TITLE
Updated PickerMatchModule.java to fix NullPointerException

### DIFF
--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -312,9 +312,11 @@ public class PickerMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
   public void cancelArmorEquip(ObserverInteractEvent event) {
-    if (event == null) { return;}
-    if (event.getClickType() == ClickType.RIGHT
-        && event.getClickedItem().getType() == Button.TEAM_JOIN.material) {
+    if (event.getClickedItem() == null) {
+      return;
+    }
+
+    if (event.getClickType() == ClickType.RIGHT && event.getClickedItem() != null && event.getClickedItem().getType() == Button.TEAM_JOIN.material) {
       event.setCancelled(true);
       event.getPlayer().getBukkit().updateInventory();
     }


### PR DESCRIPTION
Updated the PickerMatchModule.java to add a check to see if the ObserverInteractEvent item is null then checks to see the click type is right mouse. After it checks if the item isn't null and the right mouse is the team join material to continue code execution. 